### PR TITLE
FEATURE: allow authorisation call to determine final landing path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    discourse_subscription_client (0.1.0.pre14)
+    discourse_subscription_client (0.1.0.pre15)
 
 GEM
   remote: https://rubygems.org/
@@ -231,6 +231,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/discourse_subscription_client/suppliers_controller.rb
+++ b/app/controllers/discourse_subscription_client/suppliers_controller.rb
@@ -13,7 +13,10 @@ module DiscourseSubscriptionClient
     def authorize
       final_landing_path = params[:final_landing_path]
 
-      DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path = final_landing_path unless return_path.blank?
+      # default the final landing path of an authorisation loop to the subscriptions client plugin location,
+      # but allow this to be changed by inclusion of a parameter to tailor it for each individual plugin
+      # leveraging the gem.
+      session[:final_landing_path] = return_path.blank? ? "/admin/plugins/subscription-client/subscriptions" : final_landing_path
 
       request_id = DiscourseSubscriptionClient::Authorization.request_id(@supplier.id)
       cookies[:user_api_request_id] = request_id
@@ -40,8 +43,8 @@ module DiscourseSubscriptionClient
 
       DiscourseSubscriptionClient::Subscriptions.update
 
-      if !DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path.blank?
-        redirect_to DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path
+      if !session[:final_landing_path].blank?
+        redirect_to session[:final_landing_path]
       else
         redirect_to "/admin/plugins"
       end

--- a/app/controllers/discourse_subscription_client/suppliers_controller.rb
+++ b/app/controllers/discourse_subscription_client/suppliers_controller.rb
@@ -11,12 +11,7 @@ module DiscourseSubscriptionClient
     end
 
     def authorize
-      final_landing_path = params[:final_landing_path]
-
-      # default the final landing path of an authorisation loop to the subscriptions client plugin location,
-      # but allow this to be changed by inclusion of a parameter to tailor it for each individual plugin
-      # leveraging the gem.
-      session[:final_landing_path] = final_landing_path.blank? ? "/admin/plugins/subscription-client/subscriptions" : final_landing_path
+      session[:final_landing_path] = params[:final_landing_path]
 
       request_id = DiscourseSubscriptionClient::Authorization.request_id(@supplier.id)
       cookies[:user_api_request_id] = request_id

--- a/app/controllers/discourse_subscription_client/suppliers_controller.rb
+++ b/app/controllers/discourse_subscription_client/suppliers_controller.rb
@@ -16,7 +16,7 @@ module DiscourseSubscriptionClient
       # default the final landing path of an authorisation loop to the subscriptions client plugin location,
       # but allow this to be changed by inclusion of a parameter to tailor it for each individual plugin
       # leveraging the gem.
-      session[:final_landing_path] = return_path.blank? ? "/admin/plugins/subscription-client/subscriptions" : final_landing_path
+      session[:final_landing_path] = final_landing_path.blank? ? "/admin/plugins/subscription-client/subscriptions" : final_landing_path
 
       request_id = DiscourseSubscriptionClient::Authorization.request_id(@supplier.id)
       cookies[:user_api_request_id] = request_id

--- a/app/controllers/discourse_subscription_client/suppliers_controller.rb
+++ b/app/controllers/discourse_subscription_client/suppliers_controller.rb
@@ -13,9 +13,7 @@ module DiscourseSubscriptionClient
     def authorize
       final_landing_path = params[:final_landing_path]
 
-      if !return_path.blank?
-        DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path = final_landing_path
-      end
+      DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path = final_landing_path unless return_path.blank?
 
       request_id = DiscourseSubscriptionClient::Authorization.request_id(@supplier.id)
       cookies[:user_api_request_id] = request_id

--- a/app/controllers/discourse_subscription_client/suppliers_controller.rb
+++ b/app/controllers/discourse_subscription_client/suppliers_controller.rb
@@ -11,6 +11,12 @@ module DiscourseSubscriptionClient
     end
 
     def authorize
+      return_path = params[:return_path]
+
+      if !return_path.blank?
+        DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_redirect_path = return_path
+      end
+
       request_id = DiscourseSubscriptionClient::Authorization.request_id(@supplier.id)
       cookies[:user_api_request_id] = request_id
       redirect_to DiscourseSubscriptionClient::Authorization.url(current_user, @supplier, request_id).to_s,
@@ -36,7 +42,11 @@ module DiscourseSubscriptionClient
 
       DiscourseSubscriptionClient::Subscriptions.update
 
-      redirect_to "/admin/plugins/subscription-client/subscriptions"
+      if !DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_redirect_path.blank?
+        redirect_to DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_redirect_path
+      else
+        redirect_to "/admin/plugins"
+      end
     end
 
     def destroy

--- a/app/controllers/discourse_subscription_client/suppliers_controller.rb
+++ b/app/controllers/discourse_subscription_client/suppliers_controller.rb
@@ -11,10 +11,10 @@ module DiscourseSubscriptionClient
     end
 
     def authorize
-      return_path = params[:return_path]
+      final_landing_path = params[:final_landing_path]
 
       if !return_path.blank?
-        DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_redirect_path = return_path
+        DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path = final_landing_path
       end
 
       request_id = DiscourseSubscriptionClient::Authorization.request_id(@supplier.id)
@@ -42,8 +42,8 @@ module DiscourseSubscriptionClient
 
       DiscourseSubscriptionClient::Subscriptions.update
 
-      if !DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_redirect_path.blank?
-        redirect_to DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_redirect_path
+      if !DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path.blank?
+        redirect_to DiscourseSubscriptionClient::Authorization.completed_authorisation_callback_final_landing_path
       else
         redirect_to "/admin/plugins"
       end

--- a/lib/discourse_subscription_client/authorization.rb
+++ b/lib/discourse_subscription_client/authorization.rb
@@ -4,7 +4,9 @@ module DiscourseSubscriptionClient
   class Authorization
     SCOPE ||= "discourse-subscription-server:user_subscription"
 
-    @@completed_authorisation_callback_redirect_path = ""
+    # default the final landing path of an authorisation loop to the subscriptions plugin location,
+    # but allow this to be changed by inclusion of a parameter in the authorize method of the Suppliers Controller
+    @@completed_authorisation_callback_final_landing_path = "/admin/plugins/subscription-client/subscriptions"
 
     def self.request_id(supplier_id)
       "#{supplier_id}-#{SecureRandom.hex(32)}"
@@ -99,12 +101,12 @@ module DiscourseSubscriptionClient
       PluginStore.remove(DiscourseSubscriptionClient::PLUGIN_NAME, "#{keys_db_key}_#{request_id}")
     end
 
-    def self.completed_authorisation_callback_redirect_path
-      @@completed_authorisation_callback_redirect_path
+    def self.completed_authorisation_callback_final_landing_path
+      @@completed_authorisation_callback_final_landing_path
     end
 
-    def self.completed_authorisation_callback_redirect_path=(path)
-      @@completed_authorisation_callback_redirect_path = path
+    def self.completed_authorisation_callback_final_landing_path=(path)
+      @@completed_authorisation_callback_final_landing_path = path
     end
   end
 end

--- a/lib/discourse_subscription_client/authorization.rb
+++ b/lib/discourse_subscription_client/authorization.rb
@@ -4,11 +4,6 @@ module DiscourseSubscriptionClient
   class Authorization
     SCOPE ||= "discourse-subscription-server:user_subscription"
 
-    # default the final landing path of an authorisation loop to the subscriptions client plugin location,
-    # but allow this to be changed by inclusion of a parameter in the authorize method of the Suppliers Controller
-    # to tailor it for each individual plugin leveraging the gem.
-    @@completed_authorisation_callback_final_landing_path = "/admin/plugins/subscription-client/subscriptions"
-
     def self.request_id(supplier_id)
       "#{supplier_id}-#{SecureRandom.hex(32)}"
     end
@@ -100,14 +95,6 @@ module DiscourseSubscriptionClient
 
     def self.delete_keys(request_id)
       PluginStore.remove(DiscourseSubscriptionClient::PLUGIN_NAME, "#{keys_db_key}_#{request_id}")
-    end
-
-    def self.completed_authorisation_callback_final_landing_path
-      @@completed_authorisation_callback_final_landing_path
-    end
-
-    def self.completed_authorisation_callback_final_landing_path=(path)
-      @@completed_authorisation_callback_final_landing_path = path
     end
   end
 end

--- a/lib/discourse_subscription_client/authorization.rb
+++ b/lib/discourse_subscription_client/authorization.rb
@@ -4,6 +4,8 @@ module DiscourseSubscriptionClient
   class Authorization
     SCOPE ||= "discourse-subscription-server:user_subscription"
 
+    @@completed_authorisation_callback_redirect_path = ""
+
     def self.request_id(supplier_id)
       "#{supplier_id}-#{SecureRandom.hex(32)}"
     end
@@ -95,6 +97,14 @@ module DiscourseSubscriptionClient
 
     def self.delete_keys(request_id)
       PluginStore.remove(DiscourseSubscriptionClient::PLUGIN_NAME, "#{keys_db_key}_#{request_id}")
+    end
+
+    def self.completed_authorisation_callback_redirect_path
+      @@completed_authorisation_callback_redirect_path
+    end
+
+    def self.completed_authorisation_callback_redirect_path=(path)
+      @@completed_authorisation_callback_redirect_path = path
     end
   end
 end

--- a/lib/discourse_subscription_client/authorization.rb
+++ b/lib/discourse_subscription_client/authorization.rb
@@ -4,8 +4,9 @@ module DiscourseSubscriptionClient
   class Authorization
     SCOPE ||= "discourse-subscription-server:user_subscription"
 
-    # default the final landing path of an authorisation loop to the subscriptions plugin location,
+    # default the final landing path of an authorisation loop to the subscriptions client plugin location,
     # but allow this to be changed by inclusion of a parameter in the authorize method of the Suppliers Controller
+    # to tailor it for each individual plugin leveraging the gem.
     @@completed_authorisation_callback_final_landing_path = "/admin/plugins/subscription-client/subscriptions"
 
     def self.request_id(supplier_id)

--- a/lib/discourse_subscription_client/version.rb
+++ b/lib/discourse_subscription_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DiscourseSubscriptionClient
-  VERSION = "0.1.0.pre14"
+  VERSION = "0.1.0.pre15"
 end


### PR DESCRIPTION
To make this gem permit individual plugins to complete an authorisation loop, it must offer a definable final landing path for the authorisation process.

it's currently the subscription client subscriptions list which obviously won't exist!

Allow this to be changed by inclusion of a parameter in the authorize method of the Suppliers Controller to tailor it for each individual plugin leveraging the gem.